### PR TITLE
fix: dir operations made non-recursive by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ identities:
     password:
       value: String   The direct value to set the password to. See password section below for more.
       variable: String  The Ansible run variable to read the password from. See password section below for more.
-      policy: [ 
+      policy: [
         always        <sets the value as password each time>
         on_create     <only sets the value as password when creating user>
       ]
@@ -40,6 +40,7 @@ identities:
         - path: string/array    [required] Either a singular value or an array, representing the dir path in relation to the user's home directory to where the directory should be created.
           remove: bool    Indicates if the path should be removed. Default false.
           force: bool     Indicates if the path should be forcefully modified if it already exists. Default false.
+          recurse: bool   Indicates if the path operation should be recursively done. Default false.
           mode: string    The access control to set on the directory. Default '0755'.
       files:
         - source: string  [required] The path to the source file to copy over.

--- a/files/assertions/criteria/identities-criteria.json
+++ b/files/assertions/criteria/identities-criteria.json
@@ -164,6 +164,10 @@
                                         {
                                             "type": "boolean"
                                         },
+                                        "recurse": {
+                                            "description": "Indicates if the directory operation should be recursive. Defaults to false.",
+                                            "type": "boolean",
+                                        },
                                         "mode":
                                         {
                                             "ref": "#/definitions/non-empty-string"

--- a/tasks/dir.yml
+++ b/tasks/dir.yml
@@ -18,7 +18,7 @@
     mode: "{{ dir.mode | default('0755') }}"
     state: "{{ 'absent' if (dir.remove | default(false)) else 'directory' }}"
     force: "{{ dir.force | default(false) }}"
-    recurse: "{{ false if (dir.remove | default(false)) else true }}"
+    recurse: "{{ true if (dir.recurse | default(false)) else false }}"
     access_time: preserve
     modification_time: preserve
   loop: "{{ dir.path if (dir.path is iterable and dir.path is not string) else [dir.path] }}"


### PR DESCRIPTION
Directory operations are now non-recursive by default. A new parameter has been introduced to control recursive behavior during directory operations.